### PR TITLE
Wait for async execution to finish before terminating

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,21 @@ async function run() {
 
 // Run the action
 if (require.main === module) {
-  run();
+  (async () => {
+    try {
+      const mergedPRCount = await run();
+      if (process.env.GITHUB_ACTIONS) {
+        core.info(`Action finished. Merged ${mergedPRCount} PR(s).`);
+      }
+    } catch (error) {
+      if (process.env.GITHUB_ACTIONS) {
+        core.setFailed(`Action failed with an unhandled error: ${error.message}`);
+      } else {
+        console.error('Action failed with an unhandled error:', error);
+        process.exit(1);
+      }
+    }
+  })();
 }
 
 // Export for testing


### PR DESCRIPTION
**Discovery:**
When calling this action from another action it seems that no value provided for the out parameter `merged-pr-count`. Tested with both no PRs merged and one or more PRs merged. The merge is successful, the report is provided and correct, but `merged-pr-count` is empty.

**Hypothesis:**
Execution of the action terminates before the promise returned from the `run()` function is resolved, and `merged-pr-count` is never populated.

**Solution:**
Wait (blocking) for `run()` to finish before terminating execution of the action.